### PR TITLE
Allow manifests,  better signposting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,5 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+task :test => :spec

--- a/lib/spofford/client/config.rb
+++ b/lib/spofford/client/config.rb
@@ -63,7 +63,8 @@ module Spofford
         spofford_account_name: guess_account,
         package_only: false,
         force_zip: false,
-        verbose: false
+        verbose: false,
+        server_timeout: 120
       }.freeze
 
       def save_config(config, location = default_location)

--- a/lib/spofford/client/packager.rb
+++ b/lib/spofford/client/packager.rb
@@ -10,52 +10,62 @@ module Spofford
       include Spofford::Client::Util
       include Spofford::Client::Util::ThorLogger
 
+      class NoFilesError < StandardError
+      end
+
+      def verbose?
+        defined @verbose ? @verbose : false
+      end
+
       # allows for auto-conversion of non-JSON-array delete files
       # when `filename` is a text file with an ID on each line,
       # converts to a JSON array and writes to a tempfile
-      def map_delete_file(filename, verbose = false)
+      def map_delete_file(filename)
         say_verbose("Mapping delete file #{filename}", :cyan)
-        ext = File.extname(filename)
         # where to read the data from
         source = nil
         # what it will be called in the zip file
         result = filename
-        data = case ext
-               when '.json'
-                 say_verbose("#{filename} looks like JSON, will not transform", :cyan)
-                 nil
-               when '.csv'
-                 say_verbose("#{filename} looks like CSV, will convert to JSON array", :cyan)
-                 delimited_file_to_json(filename)
-               else
-                 say_verbose("#{filename} cannot determine format, will convert id-per-line to JSON", :cyan)
-                 # assume one ID per line
-                 lines_to_json(filename)
-               end
-        unless data.nil?
-          say_verbose("Creating temp JSON array file from #{filename}", :cyan)
-          prefix = File.basename(result, ext)
-          result = "#{prefix}.json"
-          source = Tempfile.new(['delete-', '.json'])
-          source.write(data)
-          source.close
-          source = source.path
-        end
+        data = file_data(filename)
+        source, result = tempstore_data(filename, data) unless data.nil?
         say_verbose("#{filename} => source: #{source}, zipname: #{result}", :cyan)
         # note source will be nil when we didn't have to monkey with the filename
         { source: source, zipname: File.basename(result) }
       end
 
+      def tempstore_data(filename, data)
+        say_verbose("Creating temp JSON array file from #{filename}", :cyan)
+        prefix = File.basename(filename, File.extname(filename))
+        result = "#{prefix}.json"
+        source = Tempfile.new(['delete-', '.json'])
+        source.write(data)
+        source.close
+        [source.path, result]
+      end
+
+      def file_data(filename)
+        case File.extname(filename)
+        when '.json'
+          say_verbose("#{filename} looks like JSON, will not transform", :cyan)
+        when '.csv'
+          say_verbose("#{filename} looks like CSV, will convert to JSON array", :cyan)
+          delimited_file_to_json(filename)
+        else
+          say_verbose("#{filename} cannot determine format, will convert id-per-line to JSON", :cyan)
+          lines_to_json(filename)
+        end
+      end
+
       # creates a list of hashes, with source file names and the resulting name
       # in the zip
-      def map_ingest_files(files, verbose = false)
+      def map_ingest_files(files)
         files.collect do |fn|
           result = fn.downcase
           result_base = File.basename(result)
           say_verbose("Packager: input #{fn} will be processed as #{result_base} -- ", :cyan)
           if result_base.start_with?('delete')
             say_verbose("#{result} looks like a delete file", :cyan)
-            d = map_delete_file(result, verbose)
+            d = map_delete_file(result)
             d[:source] ||= fn
             say_verbose(" -- JSON delete file:  #{d.to_s}", :cyan)
             d
@@ -66,7 +76,7 @@ module Spofford
             say_verbose("#{result} is a JSON file with 'argot' in the name, will add zipfile: add-#{result_base}", :cyan)
             { source: fn, zipname: "add-#{result_base}" }
           end
-        end
+        end.compact
       end
     end
 
@@ -126,6 +136,7 @@ module Spofford
       # Zip creation is skipped if the :test option
       def make_package
         local_package = @files.select do |f|
+          say_verbose("Inspecting #{f}")
           if File.exist?(f)
             say_verbose("Selecting file #{File.basename(f)}") if @dry_run
             true
@@ -134,20 +145,28 @@ module Spofford
             false
           end
         end
-        raise 'No readable input files found' if local_package.empty?
+        if local_package.empty?
+          raise NoFilesError, 'No readable input files found'
+        end
 
         if File.extname(local_package[0]) == '.zip'
-          say_verbose('First filename supplied is a zip, using that as ingest package', :green)
+          say('First filename supplied is a zip, using that as ingest package', :green)
           return local_package[0]
         end
 
-        mapped_filenames = map_ingest_files(local_package, verbose?)
+        mapped_filenames = map_ingest_files(local_package)
+        say_verbose("Files going into zip: #{mapped_filenames}", :yellow)
+        if mapped_filenames.nil? || mapped_filenames.empty?
+          raise NoFilesError, "Unable to determine ingest type for the supplied filenames, no package created"
+          return []
+        end
 
         unless @dry_run
           abs_dir = File.dirname(File.absolute_path(@zipfile))
           FileUtils.mkdir_p(abs_dir) unless File.directory?(abs_dir)
           Zip::File.open(@zipfile, Zip::File::CREATE) do |zipfile|
             mapped_filenames.each do |filenames|
+              say("Here is the filenames thingy: #{filenames}")
               say_verbose("Adding #{filenames[:source]} to zip file as #{filenames[:zipname]}", :green)
               zipfile.add(filenames[:zipname], filenames[:source])
             end

--- a/lib/spofford/client/util.rb
+++ b/lib/spofford/client/util.rb
@@ -39,6 +39,8 @@ module Spofford
         ids.flatten.to_json
       end
 
+      # Wrap Thor's logger to make it easier to control
+      # what gets logged
       module ThorLogger
         def shell
           @shell ||= ($stdout.isatty ? Thor::Shell::Color.new : Thor::Shell::Basic.new )
@@ -49,10 +51,16 @@ module Spofford
           false
         end
 
+        def say(msg, color = :yellow)
+          shell.say("[#{self.class.name}] #{msg}", color)
+          nil
+        end
+
         def say_verbose(msg, color = :green)
           shell.say("[#{self.class.name}] #{msg}", color) if verbose?
+          nil
         end
-      end # ThorLogger
-    end #Util
+      end
+    end
   end
 end

--- a/lib/spofford/client/version.rb
+++ b/lib/spofford/client/version.rb
@@ -1,5 +1,5 @@
 module Spofford
   module Client
-    VERSION = '0.2.1'.freeze
+    VERSION = '0.2.3'.freeze
   end
 end

--- a/spofford-client.gemspec
+++ b/spofford-client.gemspec
@@ -1,4 +1,4 @@
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'spofford/client/version'
 
@@ -8,28 +8,31 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Adam Constabaris']
   spec.email         = ['adam_constabaris@ncsu.edu']
 
-  spec.summary       = 'Client utilities for Spofford, the TRLN record ingest application.'
-  #spec.description   = %q{TODO: Write a longer description or delete this line.}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.summary       = 'Client utility for the TRLN record ingest application.'
+  spec.homepage      = 'https://github.com/trln/spofford-client'
 
-  raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.' unless spec.respond_to?(:metadata)
+  raise 'Please use RubyGems 2.0 or newer.' unless spec.respond_to?(:metadata)
+
   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'faraday', '~> 0.13'
-  spec.add_runtime_dependency 'faraday_middleware', '~> 0.12'
   spec.add_runtime_dependency 'faraday-cookie_jar', '~> 0.0.6'
+  spec.add_runtime_dependency 'faraday_middleware', '~> 0.12'
+
   spec.add_runtime_dependency 'mimemagic', '~> 0.3.2'
-  spec.add_runtime_dependency 'rubyzip', '~> 1.2.0'
   spec.add_runtime_dependency 'nokogiri', '~> 1.8'
+  spec.add_runtime_dependency 'rubyzip', '~> 1.2'
   spec.add_runtime_dependency 'thor', '~> 0.20.0'
 
   spec.add_development_dependency 'bundler', '~> 1.10'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rspec', '~> 3.6.0'
-  spec.add_development_dependency 'webmock', '~>3.1.0'
+  spec.add_development_dependency 'rake', '~> 12.3'
+  spec.add_development_dependency 'rspec', '~> 3.8'
+  spec.add_development_dependency 'webmock', '~>3.5'
 end


### PR DESCRIPTION
Allows specification of files to be ingested as a set of lines on STDIN or as an argument, e.g.

`spofford ingest --manifest < my_neat_argot_files.txt`

Added some more detailed output, including what to do if you get a timeout-style error when you submit a very large package.
