### PR TITLE
Provides fallback string in Spofford::Client::Config.guess_account

### DIFF
--- a/lib/spofford/client/config.rb
+++ b/lib/spofford/client/config.rb
@@ -16,7 +16,7 @@ module Spofford
       # Guess the Spofford account name based on current user
       # and hostname
       def self.guess_account
-        (ENV['USER'] || ENV['USERNAME']) + "@#{guess_owner}.edu"
+        (ENV['USER'] || ENV['USERNAME'] || 'nobody') + "@#{guess_owner}.edu"
       end
 
       # Get the usual storage location for the configuration

--- a/spec/spofford/client_config_spec.rb
+++ b/spec/spofford/client_config_spec.rb
@@ -12,4 +12,12 @@ describe 'Spofford::Client::Config' do
   it 'loads default configuration with nil argument' do
     expect(@context.load_config(nil)).to eq(Spofford::Client::Config::DEFAULT_CONFIG)
   end
+
+  describe '.guess_account' do
+    it 'works even if env vars are not set' do
+      allow(ENV).to receive(:[]).with('USER') { nil }
+      allow(ENV).to receive(:[]).with('USERNAME') { nil }
+      expect(Spofford::Client::Config.guess_account).to match /^nobody@/
+    end
+  end
 end


### PR DESCRIPTION
so that loading gem does not trigger nil error when expected env
vars are not set.